### PR TITLE
Add minimal PEP517 setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools"]

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,6 @@ setup(name='ipdb',
       zip_safe=True,
       test_suite='tests',
       python_requires=">=2.7",
-      install_requires=[
-          'setuptools',
-      ],
       extras_require={
           ':python_version == "2.7"': ['ipython >= 5.1.0, < 6.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           # No support for python 3.0, 3.1, 3.2.


### PR DESCRIPTION
This PR avoids use of the deprecated `setup_requires` to replace the
currently-incorrect use of `install_requires` by setting up a minimal
PEP517 compatible `pyproject.toml`. `install_requires` is for runtime
dependencies while the PEP517 `build-system` stuff is where you specify
what is needed to build or install the project, not what you need to
import the module.
